### PR TITLE
Improves the quality score on ansible galaxy.

### DIFF
--- a/tasks/labels.yml
+++ b/tasks/labels.yml
@@ -36,10 +36,12 @@
   command: >-
     docker node update --label-rm {{ item }} {{ docker_swarm_node_id }}
   delegate_to: "{{ docker_swarm_primary_manager_name }}"
-  with_items: >
-    {{ docker_swarm_current_labels |
-        list |
+  vars:
+    labels_to_add: >
+      {{ docker_swarm_current_labels | list |
         difference(docker_swarm_labels | default({}) | list) }}
+  with_items: "{{ labels_to_add }}"
+  when: (labels_to_add | length) > 0
   tags:
     - docker-swarm-labels
 


### PR DESCRIPTION
--> Executing Ansible Lint on
/molecule/default/playbook.yml...
    [104] Found a bare variable '{{ docker_swarm_current_labels |
        list |
        difference(docker_swarm_labels | default({}) | list) }}
    ' used in a 'with_items' loop. You should use the full variable syntax ('{{{{ docker_swarm_current_labels |
        list |
        difference(docker_swarm_labels | default({}) | list) }}
    }}')
    /tasks/labels.yml:35
    Task/Handler: labels | Remove old labels

    [301] Commands should not change things if nothing needs doing
    /tasks/labels.yml:35
    Task/Handler: labels | Remove old labels